### PR TITLE
Fix project building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
             <id>md5-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
+
+        <repository>
+            <id>lenis0012-repo</id>
+            <url>http://ci.lenis0012.com/plugin/repository/everything/</url>
+        </repository>
+        
         <!-- Repo access to Argon2 -->
         <repository>
             <snapshots>
@@ -34,7 +40,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.9-SNAPSHOT</version>
+            <version>1.9-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This makes it possible to build your project if user doesn't have the dependency downloaded

* Added a repository reference to your Jenkins server to download pluginutils and the updater
* Fixed the spigot api version