### PR TITLE
Add pool-size config property and limit SQLite to only connection

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/JdbcDaoFactory.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/JdbcDaoFactory.java
@@ -23,15 +23,15 @@ import com.lenis0012.bukkit.loginsecurity.database.InventoryDao;
 import com.lenis0012.bukkit.loginsecurity.database.LocationDao;
 import com.lenis0012.bukkit.loginsecurity.database.ProfileDao;
 import com.lenis0012.bukkit.loginsecurity.database.jdbc.platform.JdbcPlatform;
-import org.bukkit.configuration.ConfigurationSection;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+
+import org.bukkit.configuration.ConfigurationSection;
 
 public class JdbcDaoFactory implements DaoFactory {
     private final Logger logger;
@@ -107,7 +107,7 @@ public class JdbcDaoFactory implements DaoFactory {
     }
 
     public static JdbcDaoFactory build(Logger logger, ConfigurationSection configuration, JdbcPlatform platform) {
-        JdbcConnectionPool connectionPool = new JdbcConnectionPool(platform.configure(configuration), platform.getPingTimeout(configuration));
+        JdbcConnectionPool connectionPool = new JdbcConnectionPool(platform.configure(configuration), 10, platform.getPingTimeout(configuration));
         return new JdbcDaoFactory(logger, connectionPool, configuration.getName());
     }
 }

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/JdbcDaoFactory.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/JdbcDaoFactory.java
@@ -31,6 +31,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import javax.sql.ConnectionPoolDataSource;
+
 import org.bukkit.configuration.ConfigurationSection;
 
 public class JdbcDaoFactory implements DaoFactory {
@@ -107,7 +109,11 @@ public class JdbcDaoFactory implements DaoFactory {
     }
 
     public static JdbcDaoFactory build(Logger logger, ConfigurationSection configuration, JdbcPlatform platform) {
-        JdbcConnectionPool connectionPool = new JdbcConnectionPool(platform.configure(configuration), 10, platform.getPingTimeout(configuration));
+        int pingTimeout = platform.getPingTimeout(configuration);
+        ConnectionPoolDataSource dataSource = platform.configure(configuration);
+        int maxConnections = platform.getMaximumPoolSize(configuration);
+
+        JdbcConnectionPool connectionPool = new JdbcConnectionPool(dataSource, maxConnections, pingTimeout);
         return new JdbcDaoFactory(logger, connectionPool, configuration.getName());
     }
 }

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/platform/JdbcPlatform.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/platform/JdbcPlatform.java
@@ -18,14 +18,19 @@
 
 package com.lenis0012.bukkit.loginsecurity.database.jdbc.platform;
 
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
-
 import javax.sql.ConnectionPoolDataSource;
 
-public interface JdbcPlatform {
+import org.bukkit.configuration.ConfigurationSection;
 
-    ConnectionPoolDataSource configure(ConfigurationSection configuration);
+public abstract class JdbcPlatform {
 
-    int getPingTimeout(ConfigurationSection configuration);
+    public abstract ConnectionPoolDataSource configure(ConfigurationSection configuration);
+
+    public int getPingTimeout(ConfigurationSection configuration) {
+        return configuration.getInt("ping-timeout", 10);
+    }
+
+    public int getMaximumPoolSize(ConfigurationSection configuration) {
+        return configuration.getInt("pool-size", 25);
+    }
 }

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/platform/MysqlPlatform.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/platform/MysqlPlatform.java
@@ -19,11 +19,12 @@
 package com.lenis0012.bukkit.loginsecurity.database.jdbc.platform;
 
 import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
-import org.bukkit.configuration.ConfigurationSection;
 
 import javax.sql.ConnectionPoolDataSource;
 
-public class MysqlPlatform implements JdbcPlatform {
+import org.bukkit.configuration.ConfigurationSection;
+
+public class MysqlPlatform extends JdbcPlatform {
 
     @Override
     public ConnectionPoolDataSource configure(ConfigurationSection configuration) {
@@ -46,10 +47,5 @@ public class MysqlPlatform implements JdbcPlatform {
         dataSource.setMaintainTimeStats(false);
 
         return dataSource;
-    }
-
-    @Override
-    public int getPingTimeout(ConfigurationSection configuration) {
-        return configuration.getInt("ping-timeout", 10);
     }
 }

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/platform/SqlitePlatform.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/platform/SqlitePlatform.java
@@ -19,14 +19,15 @@
 package com.lenis0012.bukkit.loginsecurity.database.jdbc.platform;
 
 import com.lenis0012.bukkit.loginsecurity.LoginSecurity;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.sqlite.javax.SQLiteConnectionPoolDataSource;
 
-import javax.sql.ConnectionPoolDataSource;
 import java.io.File;
 
-public class SqlitePlatform implements JdbcPlatform {
+import javax.sql.ConnectionPoolDataSource;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.sqlite.javax.SQLiteConnectionPoolDataSource;
+
+public class SqlitePlatform extends JdbcPlatform {
 
     @Override
     public ConnectionPoolDataSource configure(ConfigurationSection configuration) {
@@ -40,7 +41,7 @@ public class SqlitePlatform implements JdbcPlatform {
     }
 
     @Override
-    public int getPingTimeout(ConfigurationSection configuration) {
-        return configuration.getInt("ping-timeout", 10);
+    public int getMaximumPoolSize(ConfigurationSection configuration) {
+        return 1;
     }
 }

--- a/src/main/resources/database.yml
+++ b/src/main/resources/database.yml
@@ -21,3 +21,4 @@ configuration:
     user: 'root'
     password: ''
     ping-timeout: 10
+    pool-size: 25

--- a/src/test/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/MySQLTestPlatform.java
+++ b/src/test/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/MySQLTestPlatform.java
@@ -19,12 +19,13 @@
 package com.lenis0012.bukkit.loginsecurity.database.jdbc;
 
 import com.lenis0012.bukkit.loginsecurity.database.jdbc.platform.JdbcPlatform;
-import org.bukkit.configuration.ConfigurationSection;
-import org.h2.jdbcx.JdbcDataSource;
 
 import javax.sql.ConnectionPoolDataSource;
 
-public class MySQLTestPlatform implements JdbcPlatform {
+import org.bukkit.configuration.ConfigurationSection;
+import org.h2.jdbcx.JdbcDataSource;
+
+public class MySQLTestPlatform extends JdbcPlatform {
 
     @Override
     public ConnectionPoolDataSource configure(ConfigurationSection configuration) {

--- a/src/test/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/SQLiteTestPlatform.java
+++ b/src/test/java/com/lenis0012/bukkit/loginsecurity/database/jdbc/SQLiteTestPlatform.java
@@ -19,13 +19,13 @@
 package com.lenis0012.bukkit.loginsecurity.database.jdbc;
 
 import com.lenis0012.bukkit.loginsecurity.database.jdbc.platform.JdbcPlatform;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.sqlite.javax.SQLiteConnectionPoolDataSource;
 
 import javax.sql.ConnectionPoolDataSource;
 
-public class SQLiteTestPlatform implements JdbcPlatform {
+import org.bukkit.configuration.ConfigurationSection;
+import org.sqlite.javax.SQLiteConnectionPoolDataSource;
+
+public class SQLiteTestPlatform extends JdbcPlatform {
     @Override
     public ConnectionPoolDataSource configure(ConfigurationSection configuration) {
         SQLiteConnectionPoolDataSource dataSource = new SQLiteConnectionPoolDataSource();
@@ -36,5 +36,10 @@ public class SQLiteTestPlatform implements JdbcPlatform {
     @Override
     public int getPingTimeout(ConfigurationSection configuration) {
         return 10;
+    }
+
+    @Override
+    public int getMaximumPoolSize(ConfigurationSection configuration) {
+        return 1;
     }
 }


### PR DESCRIPTION
[ZwPBerserk](https://www.spigotmc.org/members/zwpberserk.1189/) reported an issue with your plugin [here](https://www.spigotmc.org/threads/fastlogin.101192/page-67#post-2727529). 

Exception: https://pastebin.com/raw/nBi67k19

It's about that SQLite only allows one connection at the same time otherwise it will throw a "database file is locked" exception. While working on a fix I also noticed that the the pingTimeout property was incorrectly used for max connections. I fixed that too and introduced a new configuration value for the pool-size. 

Furthermore I decided chang the JDBCPlatform to an abstract class, because they share the same code for pingTimeout. If you don't like this change, I could revert it.