### PR TITLE
Update LoggingFilter.java

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/util/LoggingFilter.java
@@ -20,7 +20,7 @@ public class LoggingFilter extends AbstractFilter {
 
         message = message.toLowerCase();
         for(String word : filteredWords) {
-            if(message.contains(word)) {
+            if(message.startsWith(word)) {
                 return Result.DENY;
             }
         }


### PR DESCRIPTION
Currently the plugin checks if a message have a set of keywords ("/login", "/register", etc) and if they do have it then the message isn't broadcasted to the console.

While this is great to protect users from admins trying to spy on their passwords while they're logging in, it also gives them the oportunity to say anything they want without admins from the console being able to see it just by adding "/login", "/register" or any of the other filtered words anywhere in the message, for example:

- "Hey, ugly! /login"

This way, users can be toxic to one another or speak prohibited things and the admins wouldn't be able to see it. 

By checking if the message startsWith() the filtered words, it ensures the user is actually trying to use the commands instead of just adding they elsewhere in the message just to hide from the admins' sight.