### PR TITLE
Add an account limit per IP

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
@@ -44,6 +44,13 @@ public class LoginSecurityConfig extends AbstractConfig {
     private int passwordMaxLength = 32;
 
     /**
+     * accounts limit
+     */
+    @ConfigHeader("limit of accounts that can be registered from an IP")
+    @ConfigKey(path="Accounts.LimitAccounts")
+    private int LimitAccounts = 2;
+
+    /**
      * Join settings.
      */
     @ConfigHeader("When enabled, player gets a blindness effect when not logged in.")

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/database/ProfileRepository.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/database/ProfileRepository.java
@@ -252,9 +252,9 @@ public class ProfileRepository {
                     while(result.next()) {
                         r.add(parseResultSet(result));
                     }
-                    return r;
                 }
             }
         }
+        return r;
     }
 }

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/database/ProfileRepository.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/database/ProfileRepository.java
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit;
 import javax.sql.DataSource;
 import java.sql.*;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -240,5 +241,20 @@ public class ProfileRepository {
     private <T> void resolveError(Consumer<AsyncResult<T>> callback, Exception error) {
         Bukkit.getScheduler().runTask(loginSecurity, () ->
                 callback.accept(new AsyncResult<T>(false, null, error)));
+    }
+
+    public ArrayList<PlayerProfile> SearchUsersByIP(String ip) throws SQLException {
+        ArrayList<PlayerProfile> r = new ArrayList<>();
+        try(Connection connection = dataSource.getConnection()) {
+            try(PreparedStatement statement = connection.prepareStatement("SELECT * FROM ls_players WHERE ip_address=?;")) {
+                statement.setString(1, ip);
+                try(ResultSet result = statement.executeQuery()) {
+                    while(result.next()) {
+                        r.add(parseResultSet(result));
+                    }
+                    return r;
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/session/action/RegisterAction.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/session/action/RegisterAction.java
@@ -1,6 +1,7 @@
 package com.lenis0012.bukkit.loginsecurity.session.action;
 
 import com.lenis0012.bukkit.loginsecurity.LoginSecurity;
+import com.lenis0012.bukkit.loginsecurity.LoginSecurityConfig;
 import com.lenis0012.bukkit.loginsecurity.hashing.Algorithm;
 import com.lenis0012.bukkit.loginsecurity.session.*;
 import com.lenis0012.bukkit.loginsecurity.session.exceptions.ProfileRefreshException;
@@ -34,12 +35,14 @@ public class RegisterAction extends AuthAction {
         profile.setPassword(hash);
         profile.setHashingAlgorithm(Algorithm.BCRYPT.getId());
         try {
+            LoginSecurityConfig config = LoginSecurity.getConfiguration();
+
             ArrayList<PlayerProfile> ListByIp = plugin.datastore().getProfileRepository().SearchUsersByIP(session.getPlayer().getAddress().getAddress().toString());
             String ListUsersByIp = "";
             for (PlayerProfile user : ListByIp) { ListUsersByIp += user.getLastName()+" ";}
-            if (ListByIp.size() >= 2){
+            if (ListByIp.size() >= config.getLimitAccounts()){
                 response.setSuccess(false);
-                response.setErrorMessage( "Account limit: 2 \n Registered accounts: "+ListByIp.size()+" \n You have reached the account limit, you can enter with: "+ListUsersByIp);
+                response.setErrorMessage( "Accounts limit: "+config.getLimitAccounts()+" \n Registered accounts: "+ListByIp.size()+" \n You have reached the accounts limit, you can enter with: "+ListUsersByIp);
                 return null;
             }
             plugin.datastore().getProfileRepository().insertBlocking(profile);

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/session/action/RegisterAction.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/session/action/RegisterAction.java
@@ -34,10 +34,10 @@ public class RegisterAction extends AuthAction {
         final String hash = Algorithm.BCRYPT.hash(password);
         profile.setPassword(hash);
         profile.setHashingAlgorithm(Algorithm.BCRYPT.getId());
+        profile.setIpAddress(session.getPlayer().getAddress().getAddress().toString());
         try {
             LoginSecurityConfig config = LoginSecurity.getConfiguration();
-
-            ArrayList<PlayerProfile> ListByIp = plugin.datastore().getProfileRepository().SearchUsersByIP(session.getPlayer().getAddress().getAddress().toString());
+            ArrayList<PlayerProfile> ListByIp = plugin.datastore().getProfileRepository().SearchUsersByIP(profile.getIpAddress());
             String ListUsersByIp = "";
             for (PlayerProfile user : ListByIp) { ListUsersByIp += user.getLastName()+" ";}
             if (ListByIp.size() >= config.getLimitAccounts()){

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/session/action/RegisterAction.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/session/action/RegisterAction.java
@@ -7,6 +7,7 @@ import com.lenis0012.bukkit.loginsecurity.session.exceptions.ProfileRefreshExcep
 import com.lenis0012.bukkit.loginsecurity.storage.PlayerProfile;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.logging.Level;
 
 public class RegisterAction extends AuthAction {
@@ -33,6 +34,14 @@ public class RegisterAction extends AuthAction {
         profile.setPassword(hash);
         profile.setHashingAlgorithm(Algorithm.BCRYPT.getId());
         try {
+            ArrayList<PlayerProfile> ListByIp = plugin.datastore().getProfileRepository().SearchUsersByIP(session.getPlayer().getAddress().getAddress().toString());
+            String ListUsersByIp = "";
+            for (PlayerProfile user : ListByIp) { ListUsersByIp += user.getLastName()+" ";}
+            if (ListByIp.size() >= 2){
+                response.setSuccess(false);
+                response.setErrorMessage( "Account limit: 2 \n Registered accounts: "+ListByIp.size()+" \n You have reached the account limit, you can enter with: "+ListUsersByIp);
+                return null;
+            }
             plugin.datastore().getProfileRepository().insertBlocking(profile);
         } catch (SQLException e) {
             plugin.getLogger().log(Level.SEVERE, "Failed to register user", e);


### PR DESCRIPTION
- At the time of registration it also includes the IP.
- Add a limit of accounts that can be registered with the same IP.
- Add the Accounts.LimitAccounts configuration to be able to determine the accounts limit.
