### PR TITLE
Add config option to disable possibility to use username as a password

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/LoginSecurityConfig.java
@@ -44,6 +44,9 @@ public class LoginSecurityConfig extends AbstractConfig {
     private int passwordMinLength = 6;
     @ConfigKey(path="password-max-length")
     private int passwordMaxLength = 32;
+    @ConfigHeader("Allow players to use their username as a password.")
+    @ConfigKey(path="password.allow-username-as-password")
+    private boolean allowUsernameAsPassword = true;
 
     /**
      * Join settings.

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/commands/CommandRegister.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/commands/CommandRegister.java
@@ -49,6 +49,11 @@ public class CommandRegister extends Command {
             return;
         }
 
+        if(!config.isAllowUsernameAsPassword() && player.getName().equalsIgnoreCase(password)) {
+            reply(false, translate(ERROR_PASSWORD_SAME_AS_USERNAME));
+            return;
+        }
+
         if(config.isRegisterCaptcha()) {
             CaptchaManager captcha = plugin.getModule(CaptchaManager.class);
             captcha.giveMapItem(player, () -> {

--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/language/LanguageKeys.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/language/LanguageKeys.java
@@ -65,6 +65,7 @@ public enum LanguageKeys {
     ERROR_REFRESH_PROFILE("errorRefreshProfile"),
     ERROR_NOT_REGISTERED("errorNotRegistered"),
     ERROR_MATCH_PASSWORD("errorMatchPassword"),
+    ERROR_PASSWORD_SAME_AS_USERNAME("errorPasswordSameAsUsername"),
     /**
      * Kick messages
      */


### PR DESCRIPTION
This PR adds a config option `allow-username-as-password`. Setting it to false will result in forcing players to use different passwords than their usernames.
Created this PR as I implemented it a while ago for my server - I had a lot of hacked accounts due to players not setting passwords complex enough.