### PR TITLE
Add PacketType.Play.Client.WINDOW_CLICK to the inventory packet listener

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/InventoryPacketListener.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/InventoryPacketListener.java
@@ -16,7 +16,7 @@ public class InventoryPacketListener extends PacketAdapter {
     }
 
     public InventoryPacketListener(Plugin plugin) {
-        super(plugin, ListenerPriority.LOW, PacketType.Play.Server.WINDOW_ITEMS, PacketType.Play.Server.SET_SLOT, PacketType.Play.Server.WINDOW_DATA);
+        super(plugin, ListenerPriority.LOW, PacketType.Play.Server.WINDOW_ITEMS, PacketType.Play.Server.SET_SLOT, PacketType.Play.Server.WINDOW_DATA, PacketType.Play.Client.WINDOW_CLICK);
     }
 
     @Override


### PR DESCRIPTION
Prevents fiddling with the inventory of other players while not logged in by dropping incoming window click packets, as I noticed that if you spam click on a slot and then open and close the inventory it allows you to move items around, which is annoying.