### PR TITLE
Improvement to hide-inventory-safe

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/InventoryPacketListener.java
+++ b/src/main/java/com/lenis0012/bukkit/loginsecurity/modules/general/InventoryPacketListener.java
@@ -16,24 +16,37 @@ public class InventoryPacketListener extends PacketAdapter {
     }
 
     public InventoryPacketListener(Plugin plugin) {
-        super(plugin, ListenerPriority.LOW, PacketType.Play.Server.WINDOW_ITEMS, PacketType.Play.Server.SET_SLOT, PacketType.Play.Server.WINDOW_DATA);
+        super(plugin, ListenerPriority.LOW, PacketType.Play.Server.WINDOW_ITEMS, PacketType.Play.Server.SET_SLOT, PacketType.Play.Server.WINDOW_DATA, PacketType.Play.Client.WINDOW_CLICK);
     }
 
-    @Override
-    public void onPacketSending(PacketEvent event) {
+    private boolean hideInvCheck(PacketEvent event) {
         if(!LoginSecurity.getConfiguration().isHideInventory()) {
-            return;
+            return false;
         }
 
         if(event.getPacket().getIntegers().read(0) != 0) {
-            return;
+            return false;
         }
 
         PlayerSession session = LoginSecurity.getSessionManager().getPlayerSession(event.getPlayer());
         if(session.isAuthorized() || !session.isRegistered()) {
-            return;
+            return false;
         }
 
-        event.setCancelled(true);
+        return true;
+    }
+    
+    @Override
+    public void onPacketReceiving(PacketEvent event) {
+        if (hideInvCheck(event) == true) {
+            event.setCancelled(true);
+        }
+    }
+
+    @Override
+    public void onPacketSending(PacketEvent event) {
+        if (hideInvCheck(event) == true) {
+            event.setCancelled(true);
+        }
     }
 }


### PR DESCRIPTION
This PR stops the client from messing with the inventory while logged out, as I noticed an issue where it was possible to blindly manipulate the inventory while not logged in (spamming click on slots and then opening and reopening the inventory.)

The packets to do so are simply ignored now, resolving said issue.